### PR TITLE
Fixing issue with incorrect bootloader filename on S2

### DIFF
--- a/bin/beta_0_14_0-b3/manifest.json
+++ b/bin/beta_0_14_0-b3/manifest.json
@@ -20,7 +20,7 @@
     {
       "chipFamily": "ESP32-S2",
       "parts": [
-        { "path": "esp32-c2_bootloader.bin", "offset": 0 },
+        { "path": "esp32-s2_bootloader.bin", "offset": 0 },
         { "path": "WLED_0.14.0-b3_ESP32-S2.bin", "offset": 65536 }
       ]
     },


### PR DESCRIPTION
Was probably a typo in the filename.
Reported by `mcwnuq` on discord